### PR TITLE
Fixes #3 & #4: Add new sections dynamically;

### DIFF
--- a/APLExpandableCollectionViewDemo/APLExpandableCollectionViewDemo/APLCollectionViewCell.h
+++ b/APLExpandableCollectionViewDemo/APLExpandableCollectionViewDemo/APLCollectionViewCell.h
@@ -12,5 +12,6 @@
 
 @property (weak, nonatomic) IBOutlet UILabel *label;
 @property (weak, nonatomic) IBOutlet UIView *indentView;
+@property (weak, nonatomic) IBOutlet UIButton *button;
 
 @end

--- a/APLExpandableCollectionViewDemo/APLExpandableCollectionViewDemo/APLViewController.m
+++ b/APLExpandableCollectionViewDemo/APLExpandableCollectionViewDemo/APLViewController.m
@@ -11,12 +11,16 @@
 
 @interface APLViewController ()
 
+@property (strong, nonatomic) NSMutableArray *sections;
+- (IBAction)addSection:(id)sender;
 @end
 
 @implementation APLViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    self.sections = [NSMutableArray arrayWithObjects:@"Section", @"Section", nil];
     
     BOOL isiPad = [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad;
     CGFloat sectionInsetX = isiPad ? 14. : 8.;
@@ -39,7 +43,7 @@
 #pragma mark - UICollectionViewDataSource
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView {
-    return 7;
+    return self.sections.count;
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
@@ -53,13 +57,20 @@
         cell.label.text = [NSString stringWithFormat:@"Section %li", (long)indexPath.section + 1];
         cell.backgroundColor = [UIColor colorWithRed:58./255. green:165./255. blue:192./255. alpha:1.];
         cell.indentView.hidden = YES;
+        cell.button.hidden = NO;
     } else {
         cell.label.text = [NSString stringWithFormat:@"Item %li", (long)indexPath.row];
         cell.backgroundColor = [UIColor colorWithRed:58./255. green:165./255. blue:192./255. alpha:.5];
         cell.indentView.hidden = NO;
+        cell.button.hidden = YES;
     }
     
     return cell;
 }
 
+- (IBAction)addSection:(id)sender {
+    [self.sections addObject:@"Section"];
+    [self.collectionView addExpandedSection:NO];
+    [self.collectionView reloadData];
+}
 @end

--- a/APLExpandableCollectionViewDemo/APLExpandableCollectionViewDemo/Base.lproj/Main.storyboard
+++ b/APLExpandableCollectionViewDemo/APLExpandableCollectionViewDemo/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="Txa-OM-4v4">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="Txa-OM-4v4">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -23,16 +24,23 @@
                                     <subviews>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U2h-15-p0G">
                                             <rect key="frame" x="129" y="11" width="42" height="21"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view hidden="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k3w-kj-GAJ">
                                             <rect key="frame" x="0.0" y="0.0" width="30" height="44"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                                         </view>
+                                        <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="contactAdd" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IBj-T0-VeX">
+                                            <rect key="frame" x="270" y="14" width="22" height="22"/>
+                                            <state key="normal">
+                                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="addSection:" destination="Txa-OM-4v4" eventType="touchUpInside" id="TLS-08-R5X"/>
+                                            </connections>
+                                        </button>
                                     </subviews>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 </view>
@@ -43,6 +51,7 @@
                                 </constraints>
                                 <size key="customSize" width="300" height="44"/>
                                 <connections>
+                                    <outlet property="button" destination="IBj-T0-VeX" id="ims-Yt-UMP"/>
                                     <outlet property="indentView" destination="k3w-kj-GAJ" id="U2g-Co-X3Y"/>
                                     <outlet property="label" destination="U2h-15-p0G" id="hNk-QC-T1N"/>
                                 </connections>

--- a/Classes/APLExpandableCollectionView.h
+++ b/Classes/APLExpandableCollectionView.h
@@ -23,5 +23,6 @@
 
 /** Returns YES if the specified section is expanded. */
 - (BOOL)isExpandedSection:(NSInteger)section;
+- (void)addExpandedSection:(BOOL)isExpanded;
 
 @end

--- a/Classes/APLExpandableCollectionView.m
+++ b/Classes/APLExpandableCollectionView.m
@@ -63,6 +63,12 @@
     return [self.expandedSections[section] boolValue];
 }
 
+- (void)addExpandedSection:(BOOL)isExpanded {
+    if (self.expandedSections) {
+        [self.expandedSections addObject:@NO];
+    }
+}
+
 - (NSArray*)indexPathsForSection:(NSInteger)section {
     NSMutableArray* indexPaths = [NSMutableArray array];
     for (NSInteger i = 1, maxI = [self.myDataSource collectionView:self numberOfItemsInSection:section]; i < maxI; i++) {

--- a/Classes/APLExpandableSectionFlowLayout.m
+++ b/Classes/APLExpandableSectionFlowLayout.m
@@ -13,8 +13,8 @@
 #pragma mark - updates
 
 -(void)prepareLayout {
-    [self updatePreviousLayoutAttributes];
     [super prepareLayout];
+    [self updatePreviousLayoutAttributes];
 }
 
 - (void)prepareForCollectionViewUpdates:(NSArray *)updateItems {


### PR DESCRIPTION
[self updatePreviousLayoutAttributes] is called after [super prepareLayout] because it leads to wrong results and a crash.
Method for adding expanded section flag when adding new section - if we don't set this the app will crash.